### PR TITLE
Add wolfmath.c

### DIFF
--- a/examples/wolfcrypt/Makefile
+++ b/examples/wolfcrypt/Makefile
@@ -158,6 +158,7 @@ C_SOURCE_FILES += $(abspath ../../external/wolfssl/wolfcrypt/src/ecc.c)
 # math libraries
 C_SOURCE_FILES += $(abspath ../../external/wolfssl/wolfcrypt/src/tfm.c)
 C_SOURCE_FILES += $(abspath ../../external/wolfssl/wolfcrypt/src/integer.c)
+C_SOURCE_FILES += $(abspath ../../external/wolfssl/wolfcrypt/src/wolfmath.c)
 C_SOURCE_FILES += $(abspath ../../external/wolfssl/wolfcrypt/src/fe_low_mem.c)
 C_SOURCE_FILES += $(abspath ../../external/wolfssl/wolfcrypt/src/ge_low_mem.c)
 # port


### PR DESCRIPTION
This commit add wolfmath.c, which fixes the following linking error.

> /opt/toolchains/arm-none-eabi/bin/ld: _build/ecc.o: in function `ecc_projective_add_point':
/Users/user/nRF51_SDK_10/external/wolfssl/wolfcrypt/src/ecc.c:1610: undefined reference to `get_digit_count'
/opt/toolchains/arm-none-eabi/bin/ld: _build/ecc.o: in function `wc_ecc_mulmod_ex':
/Users/user/nRF51_SDK_10/external/wolfssl/wolfcrypt/src/ecc.c:2774: undefined reference to `get_digit_count'
/opt/toolchains/arm-none-eabi/bin/ld: /Users/user/nRF51_SDK_10/external/wolfssl/wolfcrypt/src/ecc.c:2784: undefined reference to `get_digit'
/opt/toolchains/arm-none-eabi/bin/ld: /Users/user/nRF51_SDK_10/external/wolfssl/wolfcrypt/src/ecc.c:2877: undefined reference to `wc_off_on_addr'
/opt/toolchains/arm-none-eabi/bin/ld: _build/ecc.o: in function `wc_ecc_point_is_at_infinity':
/Users/user/nRF51_SDK_10/external/wolfssl/wolfcrypt/src/ecc.c:3717: undefined reference to `get_digit_count'
/opt/toolchains/arm-none-eabi/bin/ld: /Users/user/nRF51_SDK_10/external/wolfssl/wolfcrypt/src/ecc.c:3717: undefined reference to `get_digit_count'
/opt/toolchains/arm-none-eabi/bin/ld: _build/ecc.o: in function `wc_ecc_export_ex':
/Users/user/nRF51_SDK_10/external/wolfssl/wolfcrypt/src/ecc.c:6727: undefined reference to `wc_export_int'
/opt/toolchains/arm-none-eabi/bin/ld: /Users/user/nRF51_SDK_10/external/wolfssl/wolfcrypt/src/ecc.c:6706: undefined reference to `wc_export_int'
/opt/toolchains/arm-none-eabi/bin/ld: /Users/user/nRF51_SDK_10/external/wolfssl/wolfcrypt/src/ecc.c:6717: undefined reference to `wc_export_int'